### PR TITLE
fix readme circup instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install radial_controller
+    circup install adafruit_radial_controller
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
resolves the following issue for this repo: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/issues/407

Editted by: tekktrik (removing auto-issue linking)